### PR TITLE
Add SecureTar v3 support, hardened extraction, and unencrypted/non-standard-key backups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ build/
 *.tar.gz
 
 .DS_Store
+
+CLAUDE.md

--- a/decrypt_backup.py
+++ b/decrypt_backup.py
@@ -33,6 +33,7 @@ from cryptography.hazmat.primitives.ciphers import (
     modes,
 )
 import hashlib
+import hmac
 import nacl.bindings.crypto_secretstream as nss
 import nacl.encoding
 from nacl.hash import blake2b
@@ -85,8 +86,29 @@ def sanitize_filename(name):
     return name
 
 def tar_filter(member, dest_path):
-    """Filter for tar extraction to handle cross-platform filename issues."""
+    """Filter for tar extraction: sanitizes filenames for Windows and blocks
+    path traversal / symlink escapes. Passing a custom filter to extractall()
+    bypasses tarfile's built-in 'data' filter protections entirely, so those
+    checks have to be reimplemented here instead of assumed."""
     member.name = sanitize_filename(member.name)
+
+    dest_root = os.path.realpath(dest_path)
+    target_path = os.path.realpath(os.path.join(dest_path, member.name))
+    if os.path.commonpath([dest_root, target_path]) != dest_root:
+        raise tarfile.FilterError(
+            f"Blocked path traversal attempt in tar member: {member.name}"
+        )
+
+    if member.issym() or member.islnk():
+        link_target = os.path.realpath(
+            os.path.join(dest_path, os.path.dirname(member.name), member.linkname)
+        )
+        if os.path.commonpath([dest_root, link_target]) != dest_root:
+            raise tarfile.FilterError(
+                f"Blocked tar member with unsafe link target: "
+                f"{member.name} -> {member.linkname}"
+            )
+
     return member
 
 def extract_key_from_kit(kit_path):
@@ -210,7 +232,7 @@ class SecureTarFile:
 
         root_key = derive_v3_root_key(self._password, root_salt)
         validation_key = derive_v3_stream_key(root_key, validation_salt)
-        if validation_key != stored_validation_key:
+        if not hmac.compare_digest(validation_key, stored_validation_key):
             raise tarfile.ReadError("Invalid password for SecureTar v3 file")
 
         stream_key = derive_v3_stream_key(root_key, derivation_salt)

--- a/decrypt_backup.py
+++ b/decrypt_backup.py
@@ -57,6 +57,12 @@ SECURETAR_FILE_METADATA_FORMAT = "!Q8x"
 
 AES_IV_SIZE = 16
 
+# Real gzip streams always start with this; SecureTar's own encrypted output
+# never coincidentally does, so it doubles as an "is this actually
+# unencrypted?" check (same heuristic Home Assistant's own securetar package
+# uses internally).
+GZIP_MAGIC_BYTES = b"\x1f\x8b\x08"
+
 # SecureTar v3 (XChaCha20-Poly1305 secretstream) cipher-init layout:
 # root salt + validation salt + validation key + derivation salt + stream header
 V3_DERIVED_KEY_SALT_SIZE = 16
@@ -278,6 +284,11 @@ class SecureTarFile:
         data, self._v3_buffer = self._v3_buffer[:size], self._v3_buffer[size:]
         return data
 
+def is_unencrypted_tar_gz(filename):
+    """Check whether filename is already a plain (unencrypted) gzip stream."""
+    with open(filename, 'rb') as f:
+        return f.read(len(GZIP_MAGIC_BYTES)) == GZIP_MAGIC_BYTES
+
 def extract_tar(filename):
     """Extract regular tar file."""
     _dirname = '.'.join(filename.split('.')[:-1])
@@ -290,8 +301,26 @@ def extract_tar(filename):
     _tar.extractall(path=_dirname, filter=tar_filter)
     return _dirname
 
+def extract_plain_tar_gz(filename):
+    """Extract an unencrypted tar.gz component (no SecureTar wrapping)."""
+    _dirname = '.'.join(filename.split('.')[:-2])
+    print(f'📦 Extracting {filename.split("/")[-1]} (unencrypted)...')
+    try:
+        with tarfile.open(name=filename, mode="r:gz") as _tar:
+            _tar.extractall(path=_dirname, filter=tar_filter)
+    except tarfile.ReadError as e:
+        print(f"❌ Error: Unable to extract {filename.split('/')[-1]}: {e}")
+        return None
+    except Exception as e:
+        print(f"❌ Error during extraction: {str(e)}")
+        return None
+    return _dirname
+
 def extract_secure_tar(filename, password):
     """Extract encrypted tar file."""
+    if is_unencrypted_tar_gz(filename):
+        return extract_plain_tar_gz(filename)
+
     _dirname = '.'.join(filename.split('.')[:-2])
     print(f'🔓 Decrypting {filename.split("/")[-1]}...')
     try:
@@ -370,7 +399,13 @@ def main():
     args = parse_args()
 
     # Handle key: CLI arg > emergency kit > manual input
+    # --key is unrestricted (empty/blank is treated as "not provided" and
+    # falls through to kit detection / manual entry): third-party add-ons
+    # (e.g. Google Drive Backup) let users set an arbitrary password, not
+    # necessarily HA's own emergency-kit format, so we only enforce that
+    # format where it's actually guaranteed to apply.
     key = args.key
+    key_from_cli = bool(key)
 
     if not key:
         # Look for emergency kit file
@@ -398,8 +433,12 @@ def main():
                 break
             else:
                 print("❌ Invalid key format. Please try again.")
+    elif key_from_cli:
+        # --key is used verbatim as the password, no format restriction
+        print("✅ Using provided key")
     else:
-        # Validate key format from CLI
+        # Key came from the emergency kit, already extracted via the strict
+        # format regex in extract_key_from_kit() - re-validate defensively.
         if not re.match(r'^([A-Z0-9]{4}-){6}[A-Z0-9]{4}$', key):
             print("❌ Error: Invalid key format!")
             print("Key should be in the format: XXXX-XXXX-XXXX-XXXX-XXXX-XXXX-XXXX")

--- a/decrypt_backup.py
+++ b/decrypt_backup.py
@@ -345,12 +345,22 @@ Examples:
   %(prog)s --key XXXX-XXXX-XXXX-XXXX-XXXX-XXXX-XXXX
   %(prog)s --key XXXX-XXXX-XXXX-XXXX-XXXX-XXXX-XXXX --file backup.tar
   %(prog)s --key XXXX-XXXX-XXXX-XXXX-XXXX-XXXX-XXXX --output-dir ./decrypted
+
+  # Third-party add-on backup (e.g. Google Drive Backup) using its own
+  # non-standard key/password instead of a Home Assistant emergency-kit key:
+  %(prog)s --key 'my-google-drive-backup-password' --file 584e4299.tar
         """
     )
     parser.add_argument(
         '--key',
         '-k',
-        help='Encryption key (format: XXXX-XXXX-XXXX-XXXX-XXXX-XXXX-XXXX)'
+        help='Encryption key. Home Assistant emergency-kit keys use the '
+             'format XXXX-XXXX-XXXX-XXXX-XXXX-XXXX-XXXX, but that format is '
+             'only enforced when the key is read from an emergency kit file '
+             'or entered interactively. A key passed here via --key is used '
+             'verbatim with no format check, since some third-party add-ons '
+             '(e.g. Google Drive Backup) let users set an arbitrary '
+             'password instead.'
     )
     parser.add_argument(
         '--file',

--- a/decrypt_backup.py
+++ b/decrypt_backup.py
@@ -89,25 +89,31 @@ def tar_filter(member, dest_path):
     """Filter for tar extraction: sanitizes filenames for Windows and blocks
     path traversal / symlink escapes. Passing a custom filter to extractall()
     bypasses tarfile's built-in 'data' filter protections entirely, so those
-    checks have to be reimplemented here instead of assumed."""
+    checks have to be reimplemented here instead of assumed.
+
+    Unsafe members are skipped (not extracted) rather than aborting the whole
+    archive: real HA add-on backups legitimately contain symlinks with
+    absolute link targets (e.g. "/config", "/backup") that reflect the
+    add-on container's own mount layout and are meaningless/unsafe once
+    extracted onto a different filesystem."""
     member.name = sanitize_filename(member.name)
 
     dest_root = os.path.realpath(dest_path)
     target_path = os.path.realpath(os.path.join(dest_path, member.name))
     if os.path.commonpath([dest_root, target_path]) != dest_root:
-        raise tarfile.FilterError(
-            f"Blocked path traversal attempt in tar member: {member.name}"
-        )
+        print(f"⚠️  Skipping tar member with path traversal attempt: {member.name}")
+        return None
 
     if member.issym() or member.islnk():
         link_target = os.path.realpath(
             os.path.join(dest_path, os.path.dirname(member.name), member.linkname)
         )
         if os.path.commonpath([dest_root, link_target]) != dest_root:
-            raise tarfile.FilterError(
-                f"Blocked tar member with unsafe link target: "
+            print(
+                f"⚠️  Skipping tar member with unsafe link target: "
                 f"{member.name} -> {member.linkname}"
             )
+            return None
 
     return member
 

--- a/decrypt_backup.py
+++ b/decrypt_backup.py
@@ -8,7 +8,7 @@ Place this script in the same directory as:
 - Your backup .tar file(s)
 
 Requirements:
-pip install cryptography
+pip install cryptography pynacl
 
 Usage:
 1. Place this script in a directory with your backup files
@@ -24,6 +24,7 @@ import shutil
 import re
 import platform
 import argparse
+import struct
 from pathlib import Path
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives.ciphers import (
@@ -32,15 +33,47 @@ from cryptography.hazmat.primitives.ciphers import (
     modes,
 )
 import hashlib
+import nacl.bindings.crypto_secretstream as nss
+import nacl.encoding
+from nacl.hash import blake2b
+from nacl.pwhash.argon2id import kdf as argon2id_kdf, SALTBYTES as ARGON2_SALT_SIZE
 
 def check_requirements():
     """Check if required packages are installed."""
     try:
         import cryptography
+        import nacl
     except ImportError:
-        print("Error: Required package 'cryptography' is not installed.")
-        print("Please install it using: pip install cryptography")
+        print("Error: Required package(s) not installed.")
+        print("Please install them using: pip install cryptography pynacl")
         sys.exit(1)
+
+# SecureTar v2/v3 header: 16 bytes file ID (9-byte magic + 1-byte version +
+# 6 reserved) followed by 16 bytes metadata (8-byte plaintext size + 8 reserved).
+SECURETAR_MAGIC = b"SecureTar"
+SECURETAR_FILE_ID_FORMAT = "!9sB6s"
+SECURETAR_FILE_METADATA_FORMAT = "!Q8x"
+
+AES_IV_SIZE = 16
+
+# SecureTar v3 (XChaCha20-Poly1305 secretstream) cipher-init layout:
+# root salt + validation salt + validation key + derivation salt + stream header
+V3_DERIVED_KEY_SALT_SIZE = 16
+V3_DERIVED_KEY_SIZE = 32
+V3_CHACHA20_HEADER_SIZE = nss.crypto_secretstream_xchacha20poly1305_HEADERBYTES
+V3_SECRETSTREAM_ABYTES = nss.crypto_secretstream_xchacha20poly1305_ABYTES
+V3_SECRETSTREAM_CHUNK_SIZE = 1024 * 1024
+V3_KDF_OPSLIMIT = 8
+V3_KDF_MEMLIMIT = 16 * 1024 * 1024
+
+SECURETAR_V3_CIPHER_INIT_FORMAT = (
+    f"!{ARGON2_SALT_SIZE}s"
+    f"{V3_DERIVED_KEY_SALT_SIZE}s"
+    f"{V3_DERIVED_KEY_SIZE}s"
+    f"{V3_DERIVED_KEY_SALT_SIZE}s"
+    f"{V3_CHACHA20_HEADER_SIZE}s"
+)
+SECURETAR_V3_CIPHER_INIT_SIZE = struct.calcsize(SECURETAR_V3_CIPHER_INIT_FORMAT)
 
 def sanitize_filename(name):
     """Sanitize filename for Windows compatibility."""
@@ -83,26 +116,57 @@ def generate_iv(key, salt):
         temp_iv = hashlib.sha256(temp_iv).digest()
     return temp_iv[:16]
 
+def derive_v3_root_key(password, root_salt):
+    """Derive the SecureTar v3 root key from the password using Argon2id."""
+    return argon2id_kdf(
+        nss.crypto_secretstream_xchacha20poly1305_KEYBYTES,
+        password.encode(),
+        root_salt,
+        opslimit=V3_KDF_OPSLIMIT,
+        memlimit=V3_KDF_MEMLIMIT,
+    )
+
+def derive_v3_stream_key(root_key, salt):
+    """Derive a per-file SecureTar v3 stream key from the root key."""
+    return blake2b(
+        b"",
+        key=root_key,
+        salt=salt,
+        person=b"SecureTarv3",
+        encoder=nacl.encoding.RawEncoder,
+    )
+
 class SecureTarFile:
-    """Handle encrypted tar files."""
+    """Handle encrypted tar files (SecureTar v1/v2 AES-CBC and v3 XChaCha20-Poly1305)."""
     def __init__(self, filename, password):
         self._file = None
         self._name = Path(filename)
         self._tar = None
         self._tar_mode = "r|gz"
-        self._aes = None
-        self._key = password_to_key(password)
+        self._password = password
         self._decrypt = None
+        # SecureTar v3 secretstream state
+        self._v3_state = None
+        self._v3_buffer = b""
+        self._v3_pos = 0
+        self._v3_ciphertext_size = 0
+        self._v3_done = False
 
     def __enter__(self):
         self._file = self._name.open("rb")
-        cbc_rand = self.read_rand_from_header(self._file)
-        self._aes = Cipher(
-            algorithms.AES(self._key),
-            modes.CBC(generate_iv(self._key, cbc_rand)),
-            backend=default_backend(),
-        )
-        self._decrypt = self._aes.decryptor()
+        version, plaintext_size, cipher_init = self.read_header(self._file)
+
+        if version == 3:
+            self._init_v3(cipher_init, plaintext_size)
+        else:
+            key = password_to_key(self._password)
+            aes = Cipher(
+                algorithms.AES(key),
+                modes.CBC(generate_iv(key, cipher_init)),
+                backend=default_backend(),
+            )
+            self._decrypt = aes.decryptor()
+
         self._tar = tarfile.open(fileobj=self, mode=self._tar_mode)
         return self._tar
 
@@ -112,23 +176,79 @@ class SecureTarFile:
         if self._file:
             self._file.close()
 
-    def read_rand_from_header(cls, st_file):
-        """Return header bytes."""
-        SECURETAR_MAGIC = b"SecureTar\x02\x00\x00\x00\x00\x00\x00"
-        BLOCK_SIZE = 16
-        IV_SIZE = BLOCK_SIZE
-        header = st_file.read(len(SECURETAR_MAGIC))
-        if header != SECURETAR_MAGIC:
-            cbc_rand = header
-        else:
-            plaintext_size = int.from_bytes(st_file.read(8), "big")
-            st_file.read(8)  # Skip reserved bytes
-            cbc_rand = st_file.read(IV_SIZE)
-        return cbc_rand
+    def read_header(self, st_file):
+        """Parse the SecureTar header, returning (version, plaintext_size, cipher_init)."""
+        id_bytes = st_file.read(struct.calcsize(SECURETAR_FILE_ID_FORMAT))
+        magic, version, reserved = struct.unpack(SECURETAR_FILE_ID_FORMAT, id_bytes)
 
+        if magic != SECURETAR_MAGIC:
+            # Legacy (v1) format: no header, the bytes read are the CBC salt
+            return 1, None, id_bytes
+
+        if version not in (2, 3):
+            raise tarfile.ReadError(f"Unsupported SecureTar version: {version}")
+
+        metadata = st_file.read(struct.calcsize(SECURETAR_FILE_METADATA_FORMAT))
+        (plaintext_size,) = struct.unpack(SECURETAR_FILE_METADATA_FORMAT, metadata)
+
+        if version == 2:
+            cipher_init = st_file.read(AES_IV_SIZE)
+        else:
+            cipher_init = st_file.read(SECURETAR_V3_CIPHER_INIT_SIZE)
+
+        return version, plaintext_size, cipher_init
+
+    def _init_v3(self, cipher_init, plaintext_size):
+        """Set up XChaCha20-Poly1305 secretstream decryption state (SecureTar v3)."""
+        (
+            root_salt,
+            validation_salt,
+            stored_validation_key,
+            derivation_salt,
+            stream_header,
+        ) = struct.unpack(SECURETAR_V3_CIPHER_INIT_FORMAT, cipher_init)
+
+        root_key = derive_v3_root_key(self._password, root_salt)
+        validation_key = derive_v3_stream_key(root_key, validation_salt)
+        if validation_key != stored_validation_key:
+            raise tarfile.ReadError("Invalid password for SecureTar v3 file")
+
+        stream_key = derive_v3_stream_key(root_key, derivation_salt)
+
+        self._v3_state = nss.crypto_secretstream_xchacha20poly1305_state()
+        nss.crypto_secretstream_xchacha20poly1305_init_pull(
+            self._v3_state, stream_header, stream_key
+        )
+
+        num_chunks = max(1, -(-plaintext_size // V3_SECRETSTREAM_CHUNK_SIZE))
+        self._v3_ciphertext_size = plaintext_size + num_chunks * V3_SECRETSTREAM_ABYTES
 
     def read(self, size=0):
+        if self._v3_state is not None:
+            return self._read_v3(size)
         return self._decrypt.update(self._file.read(size))
+
+    def _read_v3(self, size):
+        """Fill the plaintext buffer by pulling and decrypting secretstream chunks."""
+        while len(self._v3_buffer) < size and not self._v3_done:
+            frame_size = V3_SECRETSTREAM_CHUNK_SIZE + V3_SECRETSTREAM_ABYTES
+            remaining = self._v3_ciphertext_size - self._v3_pos
+            frame_size = min(frame_size, max(remaining, 0))
+            if frame_size == 0:
+                break
+            encrypted = self._file.read(frame_size)
+            if not encrypted:
+                break
+            self._v3_pos += len(encrypted)
+            plaintext, tag = nss.crypto_secretstream_xchacha20poly1305_pull(
+                self._v3_state, encrypted
+            )
+            self._v3_buffer += plaintext
+            if tag == nss.crypto_secretstream_xchacha20poly1305_TAG_FINAL:
+                self._v3_done = True
+
+        data, self._v3_buffer = self._v3_buffer[:size], self._v3_buffer[size:]
+        return data
 
 def extract_tar(filename):
     """Extract regular tar file."""

--- a/readme.md
+++ b/readme.md
@@ -107,6 +107,8 @@ Or go to **System Preferences → Privacy & Security** and click "Allow Anyway"
 
 Supports all SecureTar versions used by Home Assistant: v1 and v2 (AES-CBC) and v3 (XChaCha20-Poly1305, the default since Home Assistant 2026.4).
 
+Also handles backup components that aren't encrypted at all (detected automatically) and third-party add-ons like Google Drive Backup that use their own non-standard key/password format — pass their key with `--key` and it's used as-is, without Home Assistant's `XXXX-XXXX-...` format check.
+
 ## Security Notes
 
 - Keep your emergency kit secure - it contains your encryption key

--- a/readme.md
+++ b/readme.md
@@ -30,7 +30,7 @@ That's it! The tool will automatically find your emergency kit and backup files.
 
 **Requirements:**
 - Python 3.7 or newer
-- `cryptography` package: `pip install cryptography`
+- `cryptography` and `pynacl` packages: `pip install cryptography pynacl`
 
 **Usage:**
 ```bash
@@ -102,6 +102,10 @@ Or go to **System Preferences → Privacy & Security** and click "Allow Anyway"
 ### "No .tar files found"
 - Ensure you have the backup `.tar` file in the same directory
 - Or use `--file` to specify the exact path
+
+## Supported Backup Formats
+
+Supports all SecureTar versions used by Home Assistant: v1 and v2 (AES-CBC) and v3 (XChaCha20-Poly1305, the default since Home Assistant 2026.4).
 
 ## Security Notes
 


### PR DESCRIPTION
## Summary
- Adds SecureTar v3 (XChaCha20-Poly1305 secretstream + Argon2id/BLAKE2b) decryption support, resolving #14. Home Assistant 2026.4+ defaults new backups to v3; the tool previously only understood v1/v2 AES-CBC and would fail with a misleading "wrong password" error on v3 archives.
- Hardens tar extraction against path traversal and unsafe symlinks: a custom `extractall(filter=...)` bypasses tarfile's own built-in protections entirely, so `tar_filter()` now re-implements them itself. Unsafe members (path traversal, symlinks escaping the destination) are skipped rather than written to disk or aborting the whole archive — verified against a real HA backup where several add-ons (crowdsec, unifi) legitimately contain symlinks with absolute container-mount targets like `/config` or `/backup` that are meaningless/unsafe once extracted outside the container.
- Switches the SecureTar v3 password-validation-key comparison to a constant-time comparison (`hmac.compare_digest`).
- Relaxes the `--key` CLI argument's format restriction: third-party add-ons (e.g. Google Drive Backup) let users set an arbitrary password rather than Home Assistant's own `XXXX-XXXX-...` emergency-kit format. The strict format check now only applies where it's guaranteed to hold (emergency-kit extraction, interactive manual entry); `--key` is used verbatim, and a blank `--key ''` falls through to kit detection / manual entry rather than attempting an empty password.
- Detects genuinely unencrypted `tar.gz` components (via the same gzip magic-byte check Home Assistant's own `securetar` package uses internally) and extracts them directly instead of futilely attempting SecureTar decryption and erroring out.

## Test plan
- [x] Unit-level validation of v3 decryption against real `securetar`-generated fixtures (single-chunk, multi-chunk >1MiB, wrong password)
- [x] Full end-to-end CLI run against a real Home Assistant 2026.6.4 backup (built-in integration, emergency-kit key) — all 17 components decrypted, byte-correct content, no leftover encrypted files
- [x] Full end-to-end CLI run against a real third-party (Google Drive Backup add-on) backup with a non-standard password — all 21 components decrypted correctly through `--key`
- [x] Regression: v2 (AES-CBC) backups still decrypt correctly
- [x] Crafted-tar tests confirming path-traversal and symlink-escape members are blocked (never written to disk) without aborting extraction of the rest of the archive
- [x] Wrong-password handling still produces a clean error, no crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)